### PR TITLE
replace any spaces in path name

### DIFF
--- a/lib/carbon.js
+++ b/lib/carbon.js
@@ -22,7 +22,7 @@ CarbonClient.prototype.write = function (metrics, timestamp) {
       for (var path in metrics) {
         if (metrics.hasOwnProperty(path)) {
           var value = metrics[path];
-          lines += [path, value, timestamp].join(' ') + '\n';
+          lines += [path.replace(/\s+/g, '-'), value, timestamp].join(' ') + '\n';
         }
       }
       socket.write(self._hostedGraphiteKey + lines, 'utf-8', function (err) {


### PR DESCRIPTION
I had this problem when running telldus2graphite, as by sensors in telldus-live had names containing spaces. Currently they mess up the line format towards graphite.

Perhaps there is a better place to put the fix?

There should also be tests, naturally. I just did not find how to incorporate them into the existing tests.